### PR TITLE
feat: Claude Codeのバージョン管理機能を追加

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,11 @@ inputs:
     description: "Timeout in minutes for execution"
     required: false
     default: "30"
+  
+  claude_code_version:
+    description: "Claude Code version to install (default: latest)"
+    required: false
+    default: "latest"
 
 outputs:
   execution_file:
@@ -86,6 +91,31 @@ runs:
       uses: oven-sh/setup-bun@v2
       with:
         bun-version: 1.2.11
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install/Update Claude Code
+      shell: bash
+      run: |
+        echo "::group::Claude Code Setup"
+        echo "Checking current Claude Code version..."
+        if command -v claude &> /dev/null; then
+          CURRENT_VERSION=$(claude --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+          echo "Current Claude Code version: $CURRENT_VERSION"
+        else
+          echo "Claude Code not installed"
+        fi
+        
+        CLAUDE_CODE_VERSION="${{ inputs.claude_code_version }}"
+        echo "Installing Claude Code version: $CLAUDE_CODE_VERSION"
+        npm install -g claude-code@$CLAUDE_CODE_VERSION
+        
+        echo "Verifying installation..."
+        claude --version
+        echo "::endgroup::"
 
     - name: Install Dependencies
       shell: bash


### PR DESCRIPTION
## 概要
GitHub ActionsでClaude Codeのバージョンを管理できる機能を追加しました。

## 背景
現在、GitHub ActionsランナーにプリインストールされているClaude Codeのバージョンが古く（1.0.2）、新しいバージョン（1.0.24以上）が必要なケースでエラーが発生していました。

## 変更内容
- 新しい入力パラメータ `claude_code_version` を追加（デフォルト: latest）
- Node.js 20のセットアップステップを追加
- Claude Codeのインストール/更新ステップを追加
  - 現在のバージョンをチェック
  - 指定されたバージョンをインストール
  - インストール後のバージョンを確認

## 使用例
```yaml
- uses: yyyamazaki/claude-code-action@main
  with:
    # デフォルト（最新版）を使用
    claude_code_version: latest
    
    # または特定のバージョンを指定
    claude_code_version: 1.0.24
```

## テスト
- [ ] GitHub Actionsでの動作確認
- [ ] 異なるバージョンでのインストール確認

🤖 Generated with [Claude Code](https://claude.ai/code)