### PR TITLE
fix: Claude Codeコマンドが見つからない問題を修正

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,8 +113,18 @@ runs:
         echo "Installing Claude Code version: $CLAUDE_CODE_VERSION"
         npm install -g claude-code@$CLAUDE_CODE_VERSION
         
+        # npmのグローバルbinディレクトリをPATHに追加
+        NPM_BIN_DIR="$(npm config get prefix)/bin"
+        export PATH="$NPM_BIN_DIR:$PATH"
+        echo "PATH=$PATH" >> $GITHUB_ENV
+        
+        # インストール場所を確認
+        echo "NPM global bin directory: $NPM_BIN_DIR"
+        echo "Looking for claude binary..."
+        ls -la "$NPM_BIN_DIR" | grep claude || true
+        
         echo "Verifying installation..."
-        claude --version
+        claude --version || (echo "Claude command not found in PATH" && exit 1)
         echo "::endgroup::"
 
     - name: Install Dependencies


### PR DESCRIPTION
## 問題
GitHub Actionsでclaude-codeをnpmでインストール後、`claude`コマンドが見つからないエラーが発生していました。

```
claude: command not found
Process completed with exit code 127
```

## 原因
npmのグローバルインストール時、バイナリがインストールされるディレクトリがPATHに含まれていなかったため。

## 修正内容
1. npmのグローバルbinディレクトリ（`npm config get prefix`/bin）を取得
2. そのディレクトリを明示的にPATHに追加
3. `GITHUB_ENV`を使用して後続のステップでもPATHを保持
4. デバッグ用にインストール場所の確認処理を追加
5. claudeコマンドが見つからない場合は明確なエラーメッセージで終了

## テスト
- [ ] GitHub Actionsでの動作確認
- [ ] claudeコマンドが正しく実行されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)